### PR TITLE
Add rendering geometries: Bézier splines, polylines, rays, lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ doc/tags/
 compile_commands.json
 out/
 CMakeSettings.json
+.idea/
+cmake-build-debug/
+cmake-build-release/
+html/
+latex/

--- a/cartocrow/core/CMakeLists.txt
+++ b/cartocrow/core/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
 	region_arrangement.cpp
 	region_map.cpp
 	timer.cpp
+	bezier.cpp
 )
 set(HEADERS
 	centroid.h
@@ -12,6 +13,7 @@ set(HEADERS
 	region_arrangement.h
 	region_map.h
 	timer.h
+	bezier.h
 )
 
 add_library(core ${SOURCES})

--- a/cartocrow/core/bezier.h
+++ b/cartocrow/core/bezier.h
@@ -27,7 +27,7 @@ Created by tvl (t.vanlankveld@esciencecenter.nl) on 08-09-2020
 
 #include "../core/core.h"
 
-namespace cartocrow::necklace_map {
+namespace cartocrow {
 
 /// A cubic Bezier curve.
 /**
@@ -39,6 +39,9 @@ class BezierCurve {
 	/// Constructs a cubic Bezier curve based on four control points.
 	BezierCurve(const Point<Inexact>& source, const Point<Inexact>& source_control,
 	            const Point<Inexact>& target_control, const Point<Inexact>& target);
+
+	/// Constructs a cubic Bezier curve from a quadratic Bezier curve consisting of three control points.
+	BezierCurve(const Point<Inexact>& source, const Point<Inexact>& control, const Point<Inexact>& target);
 
 	/// Returns the source of this curve.
 	Point<Inexact> source() const;
@@ -57,6 +60,8 @@ class BezierCurve {
 	size_t intersectRay(const Point<Inexact>& source, const Point<Inexact>& target,
 	                    Point<Inexact>* intersections, Number<Inexact>* intersection_t) const;
 
+	BezierCurve transform(const CGAL::Aff_transformation_2<Inexact> &t) const;
+
   protected:
 	// TODO control points stored as Vectors instead of Points
 	std::array<Vector<Inexact>, 4> m_controlPoints;
@@ -69,29 +74,31 @@ class BezierSpline {
 
 	BezierSpline();
 
-	bool IsValid() const;
+	bool isValid() const;
 
-	bool IsEmpty() const;
+	bool isEmpty() const;
 
-	bool IsContinuous() const;
+	bool isContinuous() const;
 
-	bool IsClosed() const;
+	bool isClosed() const;
 
-	bool ToCircle(Circle<Inexact>& circle, const Number<Inexact>& epsilon = 0.01) const;
+	bool toCircle(Circle<Inexact>& circle, const Number<Inexact>& epsilon = 0.01) const;
 
 	const CurveSet& curves() const;
 
 	CurveSet& curves();
 
-	void AppendCurve(const Point<Inexact>& source, const Point<Inexact>& source_control,
+	void appendCurve(const Point<Inexact>& source, const Point<Inexact>& source_control,
 	                 const Point<Inexact>& target_control, const Point<Inexact>& target);
 
-	void AppendCurve(const Point<Inexact>& source_control, const Point<Inexact>& target_control,
+	void appendCurve(BezierCurve curve);
+
+	void appendCurve(const Point<Inexact>& source_control, const Point<Inexact>& target_control,
 	                 const Point<Inexact>& target);
 
-	void Reverse();
+	void reverse();
 
-	Box ComputeBoundingBox() const;
+	Box computeBoundingBox() const;
 
   private:
 	CurveSet curves_;

--- a/cartocrow/core/core.cpp
+++ b/cartocrow/core/core.cpp
@@ -24,52 +24,6 @@ Created by tvl (t.vanlankveld@esciencecenter.nl) on 05-12-2019
 
 namespace cartocrow {
 
-Point<Inexact> approximate(const Point<Exact>& p) {
-	return Point<Inexact>(CGAL::to_double(p.x()), CGAL::to_double(p.y()));
-}
-
-Vector<Inexact> approximate(const Vector<Exact>& v) {
-	return Vector<Inexact>(CGAL::to_double(v.x()), CGAL::to_double(v.y()));
-}
-
-Circle<Inexact> approximate(const Circle<Exact>& c) {
-	return Circle<Inexact>(approximate(c.center()), CGAL::to_double(c.squared_radius()));
-}
-
-Line<Inexact> approximate(const Line<Exact>& l) {
-	return Line<Inexact>(CGAL::to_double(l.a()), CGAL::to_double(l.b()), CGAL::to_double(l.c()));
-}
-
-Segment<Inexact> approximate(const Segment<Exact>& s) {
-	return Segment<Inexact>(approximate(s.start()), approximate(s.end()));
-}
-
-Polygon<Inexact> approximate(const Polygon<Exact>& p) {
-	Polygon<Inexact> result;
-	for (auto v = p.vertices_begin(); v < p.vertices_end(); ++v) {
-		result.push_back(approximate(*v));
-	}
-	return result;
-}
-
-PolygonWithHoles<Inexact> approximate(const PolygonWithHoles<Exact>& p) {
-	PolygonWithHoles<Inexact> result(approximate(p.outer_boundary()));
-	for (auto hole = p.holes_begin(); hole < p.holes_end(); ++hole) {
-		result.add_hole(approximate(*hole));
-	}
-	return result;
-}
-
-PolygonSet<Inexact> approximate(const PolygonSet<Exact>& p) {
-	PolygonSet<Inexact> result;
-	std::vector<PolygonWithHoles<Exact>> polygons;
-	p.polygons_with_holes(std::back_inserter(polygons));
-	for (auto polygon : polygons) {
-		result.insert(approximate(polygon));
-	}
-	return result;
-}
-
 Number<Inexact> wrapAngle(Number<Inexact> alpha, Number<Inexact> beta) {
 	return wrap<Inexact>(alpha, beta, beta + M_2xPI);
 }

--- a/cartocrow/core/ipe_reader.cpp
+++ b/cartocrow/core/ipe_reader.cpp
@@ -19,6 +19,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "ipe_reader.h"
 
+#include "bezier.h"
+
 #include <CGAL/Boolean_set_operations_2/Gps_polygon_validation.h>
 
 #include <ipebase.h>
@@ -110,21 +112,20 @@ PolygonSet<Exact> IpeReader::convertShapeToPolygonSet(const ipe::Shape& shape,
 	return set;
 }
 
-// TODO
-/*BezierSpline IpeReader::convertPathToSpline(const ipe::SubPath& path, const ipe::Matrix& matrix) {
+BezierSpline IpeReader::convertPathToSpline(const ipe::SubPath& path, const ipe::Matrix& matrix) {
 	BezierSpline spline;
 	if (path.type() == ipe::SubPath::EClosedSpline) {
 		std::vector<ipe::Bezier> beziers;
 		path.asClosedSpline()->beziers(beziers);
 		for (auto bezier : beziers) {
-			spline.AppendCurve(
-			    Point(bezier.iV[0].x, bezier.iV[0].y), Point(bezier.iV[1].x, bezier.iV[1].y),
-			    Point(bezier.iV[2].x, bezier.iV[2].y), Point(bezier.iV[3].x, bezier.iV[3].y));
+			spline.appendCurve(
+			    Point<Inexact>(bezier.iV[0].x, bezier.iV[0].y), Point<Inexact>(bezier.iV[1].x, bezier.iV[1].y),
+			    Point<Inexact>(bezier.iV[2].x, bezier.iV[2].y), Point<Inexact>(bezier.iV[3].x, bezier.iV[3].y));
 		}
 	} else {
 		throw std::runtime_error("Only closed splines are supported for spline conversion");
 	}
 	return spline;
-}*/
+}
 
 } // namespace cartocrow

--- a/cartocrow/core/ipe_reader.h
+++ b/cartocrow/core/ipe_reader.h
@@ -23,8 +23,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <filesystem>
 #include <memory>
 
-//#include "cartocrow/core/bezier_spline.h"
 #include "core.h"
+#include "bezier.h"
 
 #include <ipeattributes.h>
 #include <ipedoc.h>
@@ -50,8 +50,7 @@ class IpeReader {
 	static PolygonSet<Exact> convertShapeToPolygonSet(const ipe::Shape& shape,
 	                                                  const ipe::Matrix& matrix);
 	/// Converts an Ipe path to a Bézier spline.
-	// TODO
-	//static BezierSpline convertPathToSpline(const ipe::SubPath& path, const ipe::Matrix& matrix);
+	static BezierSpline convertPathToSpline(const ipe::SubPath& path, const ipe::Matrix& matrix);
 };
 
 } // namespace cartocrow

--- a/cartocrow/core/polyline.h
+++ b/cartocrow/core/polyline.h
@@ -1,0 +1,120 @@
+/*
+The CartoCrow library implements algorithmic geo-visualization methods,
+developed at TU Eindhoven.
+Copyright (C) 2021  Netherlands eScience Center and TU Eindhoven
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef CARTOCROW_POLYLINE_H
+#define CARTOCROW_POLYLINE_H
+
+#include <CGAL/Point_2.h>
+#include <CGAL/Segment_2.h>
+
+namespace cartocrow {
+template <class Segment_>
+class Polyline_Segment_ptr
+{
+  public:
+	typedef Segment_ Segment;
+	Polyline_Segment_ptr(Segment const &seg) :m_seg(seg){}
+	Segment* operator->() {return &m_seg;}
+  private:
+	Segment m_seg;
+};
+
+template <class K, class InputIterator> class SegmentIterator:
+    public std::iterator<
+        std::input_iterator_tag, 			     // iterator_category
+        CGAL::Segment_2<K>, 				 	 // value_type
+        typename InputIterator::difference_type, // difference_type
+        CGAL::Segment_2<K>*,				 	 // pointer
+        CGAL::Segment_2<K>& 				 	 // reference
+        > {
+  private:
+	InputIterator m_first_vertex;
+
+  public:
+	typedef SegmentIterator<K, InputIterator> Self;
+
+	SegmentIterator(InputIterator first_vertex): m_first_vertex(first_vertex) {};
+
+	CGAL::Segment_2<K> operator*() const {
+		auto second_vertex = m_first_vertex;
+		++second_vertex;
+		return { *m_first_vertex, *second_vertex };
+	}
+
+	Polyline_Segment_ptr<CGAL::Segment_2<K>> operator->() const
+	{return Polyline_Segment_ptr<CGAL::Segment_2<K>>(operator*());}
+
+	Self& operator++() {
+		++m_first_vertex;
+		return *this;
+	}
+
+	Self operator++(int) {
+		Self tmp = *this;
+		++*this;
+		return tmp;
+	}
+
+	bool operator==(const Self& other) const {
+		return m_first_vertex == other.m_first_vertex;
+	}
+
+	bool operator!=(const Self& other) const {
+		return m_first_vertex != other.m_first_vertex;
+	}
+};
+
+template <class K> class Polyline {
+  public:
+	typedef std::vector<CGAL::Point_2<K>>::const_iterator Vertex_iterator;
+	typedef SegmentIterator<K, typename std::vector<typename CGAL::Point_2<K>>::const_iterator> Edge_iterator;
+	Polyline() = default;
+
+	template <class InputIterator> Polyline(InputIterator begin, InputIterator end) {
+		if (begin == end) {
+			throw std::runtime_error("Polyline cannot be empty.");
+		}
+		std::copy(begin, end, std::back_inserter(m_points));
+	}
+
+	explicit Polyline(std::vector<CGAL::Point_2<K>> points): m_points(points) {};
+
+	void push_back(const CGAL::Point_2<K>& p) {
+		m_points.push_back(p);
+	}
+
+	void insert(Vertex_iterator i, const CGAL::Point_2<K>& p) {
+		m_points.insert(i, p);
+	}
+
+	[[nodiscard]] Vertex_iterator vertices_begin() const { return m_points.begin(); }
+	[[nodiscard]] Vertex_iterator vertices_end() const { return m_points.end(); }
+	[[nodiscard]] Edge_iterator edges_begin() const { return { m_points.begin() }; }
+	[[nodiscard]] Edge_iterator edges_end() const { return { --m_points.end() }; }
+	[[nodiscard]] int num_vertices() const { return m_points.size(); }
+	[[nodiscard]] int num_edges() const { return m_points.size() - 1; }
+	[[nodiscard]] int size() const { return num_vertices(); }
+	[[nodiscard]] CGAL::Point_2<K> vertex(int i) const { return m_points[i]; }
+	[[nodiscard]] CGAL::Segment_2<K> edge(int i) const { return *(std::next(edges_begin(), i)); }
+  private:
+	std::vector<CGAL::Point_2<K>> m_points;
+};
+}
+
+#endif //CARTOCROW_POLYLINE_H

--- a/cartocrow/core/polyline.h
+++ b/cartocrow/core/polyline.h
@@ -82,7 +82,7 @@ template <class K, class InputIterator> class SegmentIterator:
 
 template <class K> class Polyline {
   public:
-	typedef std::vector<CGAL::Point_2<K>>::const_iterator Vertex_iterator;
+	typedef typename std::vector<CGAL::Point_2<K>>::const_iterator Vertex_iterator;
 	typedef SegmentIterator<K, typename std::vector<typename CGAL::Point_2<K>>::const_iterator> Edge_iterator;
 	Polyline() = default;
 

--- a/cartocrow/necklace_map/CMakeLists.txt
+++ b/cartocrow/necklace_map/CMakeLists.txt
@@ -16,8 +16,7 @@ set(SOURCES
 	scale_factor/compute_scale_factor.cpp
 	valid_placement/compute_valid_placement.cpp
 	bead.cpp
-	bezier.cpp
-	bezier_necklace.cpp
+    bezier_necklace.cpp
 	circle_necklace.cpp
 	circular_range.cpp
 	necklace.cpp
@@ -46,8 +45,7 @@ set(HEADERS
 	scale_factor/compute_scale_factor.h
 	valid_placement/compute_valid_placement.h
 	bead.h
-	bezier.h
-	bezier_necklace.h
+    bezier_necklace.h
 	bit_string.h
 	circle_necklace.h
 	circular_range.h

--- a/cartocrow/necklace_map/bezier_necklace.cpp
+++ b/cartocrow/necklace_map/bezier_necklace.cpp
@@ -76,12 +76,12 @@ BezierNecklace::BezierNecklace(const BezierSpline spline, const Point<Inexact>& 
 	// Clockwise curves are reversed.
 	if (CGAL::orientation(spline_.curves().begin()->source(),
 	                      spline_.curves().begin()->sourceControl(), kernel_) == CGAL::CLOCKWISE) {
-		spline_.Reverse();
+		spline_.reverse();
 	}
 
 	// Reorder the curves to start with the curve directly to the right of the kernel.
 	std::sort(spline_.curves().begin(), spline_.curves().end(), CompareBezierCurves(*this));
-	CHECK(spline_.IsClosed());
+	CHECK(spline_.isClosed());
 }
 
 const Point<Inexact>& BezierNecklace::kernel() const {
@@ -101,7 +101,7 @@ bool BezierNecklace::isValid() const {
 	// The curve must also be fully visible from the kernel, i.e. no ray originating from the kernel intersects the curve in more than one point.
 	// Finally, the curve must describe a counterclockwise sweep around the kernel, i.e. the curve must start to the left of the vector from the kernel to the curve source.
 
-	bool valid = spline_.IsValid();
+	bool valid = spline_.isValid();
 	for (const BezierCurve& curve : spline_.curves()) {
 		valid &= curve.source() != curve.sourceControl() && curve.target() != curve.targetControl() &&
 		         !CGAL::right_turn(curve.source(), curve.sourceControl(), kernel()) &&
@@ -124,7 +124,7 @@ bool BezierNecklace::intersectRay(const Number<Inexact>& angle_rad,
 }
 
 Box BezierNecklace::computeBoundingBox() const {
-	return spline_.ComputeBoundingBox();
+	return spline_.computeBoundingBox();
 }
 
 Number<Inexact> BezierNecklace::computeCoveringRadiusRad(const Range& range,

--- a/cartocrow/necklace_map/bezier_necklace.h
+++ b/cartocrow/necklace_map/bezier_necklace.h
@@ -24,7 +24,7 @@ Created by tvl (t.vanlankveld@esciencecenter.nl) on 25-02-2020
 #define CARTOCROW_NECKLACE_MAP_BEZIER_NECKLACE_H
 
 #include "../core/core.h"
-#include "bezier.h"
+#include "../core/bezier.h"
 #include "necklace_shape.h"
 
 namespace cartocrow::necklace_map {

--- a/cartocrow/renderer/geometry_renderer.cpp
+++ b/cartocrow/renderer/geometry_renderer.cpp
@@ -22,26 +22,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace cartocrow::renderer {
 
-void GeometryRenderer::draw(const Point<Exact>& p) {
-	draw(approximate(p));
-}
-
-void GeometryRenderer::draw(const Segment<Exact>& s) {
-	draw(approximate(s));
-}
-
-void GeometryRenderer::draw(const Polygon<Exact>& p) {
-	draw(approximate(p));
-}
-
-void GeometryRenderer::draw(const PolygonWithHoles<Exact>& p) {
-	draw(approximate(p));
-}
-
-void GeometryRenderer::draw(const Circle<Exact>& c) {
-	draw(approximate(c));
-}
-
 void GeometryRenderer::draw(const PolygonSet<Inexact>& ps) {
 	std::vector<PolygonWithHoles<Inexact>> polygons;
 	ps.polygons_with_holes(std::back_inserter(polygons));
@@ -50,12 +30,10 @@ void GeometryRenderer::draw(const PolygonSet<Inexact>& ps) {
 	}
 }
 
-void GeometryRenderer::draw(const PolygonSet<Exact>& ps) {
-	draw(approximate(ps));
-}
-
-void GeometryRenderer::drawText(const Point<Exact>& p, const std::string& s) {
-	drawText(approximate(p), s);
+void GeometryRenderer::draw(const BezierCurve& c) {
+	BezierSpline spline;
+	spline.appendCurve(c);
+	draw(spline);
 }
 
 } // namespace cartocrow::renderer

--- a/cartocrow/renderer/geometry_renderer.h
+++ b/cartocrow/renderer/geometry_renderer.h
@@ -20,10 +20,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef CARTOCROW_RENDERER_GEOMETRY_RENDERER_H
 #define CARTOCROW_RENDERER_GEOMETRY_RENDERER_H
 
-// TODO
-//#include "../core/bezier_spline.h"
+#include "../core/bezier.h"
 #include "../core/core.h"
 #include "../core/region_map.h"
+#include "../core/polyline.h"
 
 namespace cartocrow::renderer {
 
@@ -88,37 +88,42 @@ class GeometryRenderer {
 
 	/// Draws a single point with the currently set style.
 	virtual void draw(const Point<Inexact>& p) = 0;
-	/// Draws a single point with the currently set style.
-	void draw(const Point<Exact>& p);
 	/// Draws a single line segment with the currently set style.
 	virtual void draw(const Segment<Inexact>& s) = 0;
-	/// Draws a single line segment with the currently set style.
-	void draw(const Segment<Exact>& s);
 	/// Draws a simple polygon with the currently set style.
 	virtual void draw(const Polygon<Inexact>& p) = 0;
-	/// Draws a simple polygon with the currently set style.
-	void draw(const Polygon<Exact>& p);
 	/// Draws a polygon with holes with the currently set style.
 	virtual void draw(const PolygonWithHoles<Inexact>& p) = 0;
-	/// Draws a polygon with holes with the currently set style.
-	void draw(const PolygonWithHoles<Exact>& p);
 	/// Draws a circle with the currently set style.
 	virtual void draw(const Circle<Inexact>& c) = 0;
-	/// Draws a circle with the currently set style.
-	void draw(const Circle<Exact>& c);
 	/// Draws a Bézier spline with the currently set style.
-	//virtual void draw(const BezierSpline<Inexact>& s) = 0; // TODO
+	void draw(const BezierCurve& c);
+	/// Draws a Bézier spline with the currently set style.
+	virtual void draw(const BezierSpline& s) = 0;
 	/// Draws a polygon set with the currently set style.
 	virtual void draw(const PolygonSet<Inexact>& p);
-	/// Draws a polygon set with the currently set style.
-	void draw(const PolygonSet<Exact>& p);
+	/// Draws a line with the currently set style.
+	virtual void draw(const Line<Inexact>& l) = 0;
+	/// Draws a ray with the currently set style.
+	virtual void draw(const Ray<Inexact>& r) = 0;
+	/// Draws a polyline with the currently set style.
+	virtual void draw(const Polyline<Inexact>& p) = 0;
+
+	/// Draws an exact geometry with the currently set style by approximating it.
+	template<class ExactGeometry>
+	void draw(const ExactGeometry& g) {
+		draw(approximate(g));
+	};
 
 	/// Draws a string at a given location.
 	/// The string is drawn centered horizontally around the location given.
 	virtual void drawText(const Point<Inexact>& p, const std::string& text) = 0;
 	/// Draws a string at a given location.
 	/// The string is drawn centered horizontally around the location given.
-	void drawText(const Point<Exact>& p, const std::string& text);
+	template <class K>
+	void drawText(const Point<K>& p, const std::string& text) {
+		drawText(approximate(p), text);
+	}
 
 	/// @}
 

--- a/cartocrow/renderer/geometry_widget.cpp
+++ b/cartocrow/renderer/geometry_widget.cpp
@@ -557,7 +557,10 @@ void GeometryWidget::draw(const Ray<Inexact>& r) {
 	auto result = intersection(r, CGAL::Iso_rectangle_2<Inexact>(Point<Inexact>(bounds.xmin(), bounds.ymin()), Point<Inexact>(bounds.xmax(), bounds.ymax())));
 	if (result) {
 		if (const Segment<Inexact>* s = boost::get<Segment<Inexact>>(&*result)) {
+			int oldMode = m_style.m_mode;
+			setMode(oldMode & ~vertices);
 			draw(*s);
+			setMode(oldMode);
 		}
 		if (m_style.m_mode & vertices) {
 			draw(r.source());
@@ -570,7 +573,10 @@ void GeometryWidget::draw(const Line<Inexact>& l) {
 	auto result = intersection(l, CGAL::Iso_rectangle_2<Inexact>(Point<Inexact>(bounds.xmin(), bounds.ymin()), Point<Inexact>(bounds.xmax(), bounds.ymax())));
 	if (result) {
 		if (const Segment<Inexact>* s = boost::get<Segment<Inexact>>(&*result)) {
+			int oldMode = m_style.m_mode;
+			setMode(oldMode & ~vertices);
 			draw(*s);
+			setMode(oldMode);
 		}
 	}
 }

--- a/cartocrow/renderer/geometry_widget.h
+++ b/cartocrow/renderer/geometry_widget.h
@@ -163,7 +163,10 @@ class GeometryWidget : public QWidget, GeometryRenderer {
 	void draw(const Polygon<Inexact>& p) override;
 	void draw(const PolygonWithHoles<Inexact>& p) override;
 	void draw(const Circle<Inexact>& c) override;
-	//void draw(const BezierSpline& s) override;
+	void draw(const BezierSpline& s) override;
+	void draw(const Line<Inexact>& l) override;
+	void draw(const Ray<Inexact>& r) override;
+	void draw(const Polyline<Inexact>& p) override;
 	void drawText(const Point<Inexact>& p, const std::string& text) override;
 
 	void pushStyle() override;

--- a/cartocrow/renderer/ipe_renderer.cpp
+++ b/cartocrow/renderer/ipe_renderer.cpp
@@ -34,7 +34,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace cartocrow::renderer {
 
-IpeRenderer::IpeRenderer(std::shared_ptr<GeometryPainting> painting) {
+IpeRenderer::IpeRenderer(const std::shared_ptr<GeometryPainting>& painting) {
 	m_paintings.push_back(painting);
 }
 
@@ -105,12 +105,57 @@ void IpeRenderer::draw(const Segment<Inexact>& s) {
 	}
 }
 
+void IpeRenderer::draw(const Line<Inexact>& l) {
+	// Crop to document size
+	auto bounds = CGAL::Iso_rectangle_2<Inexact>(CGAL::ORIGIN, Point<Inexact>(1000.0, 1000.0));
+	auto result = intersection(l, bounds);
+	if (result) {
+		if (const Segment<Inexact>* s = boost::get<Segment<Inexact>>(&*result)) {
+			draw(*s);
+		}
+	}
+}
+
+void IpeRenderer::draw(const Ray<Inexact>& r) {
+	// Crop to document size
+	auto bounds = CGAL::Iso_rectangle_2<Inexact>(CGAL::ORIGIN, Point<Inexact>(1000.0, 1000.0));
+	auto result = intersection(r, bounds);
+	if (result) {
+		if (const Segment<Inexact>* s = boost::get<Segment<Inexact>>(&*result)) {
+			draw(*s);
+		}
+		if (m_style.m_mode & vertices) {
+			draw(r.source());
+		}
+	}
+}
+
+void IpeRenderer::draw(const Polyline<Inexact>& p) {
+	ipe::Curve* curve = convertPolylineToCurve(p);
+	ipe::Shape* shape = new ipe::Shape();
+	shape->appendSubPath(curve);
+	ipe::Path* path = new ipe::Path(getAttributesForStyle(), *shape);
+	m_page->append(ipe::TSelect::ENotSelected, m_layer, path);
+
+	if (m_style.m_mode & vertices) {
+		for (auto v = p.vertices_begin(); v != p.vertices_end(); v++) {
+			draw(*v);
+		}
+	}
+}
+
 void IpeRenderer::draw(const Polygon<Inexact>& p) {
 	ipe::Curve* curve = convertPolygonToCurve(p);
 	ipe::Shape* shape = new ipe::Shape();
 	shape->appendSubPath(curve);
 	ipe::Path* path = new ipe::Path(getAttributesForStyle(), *shape);
 	m_page->append(ipe::TSelect::ENotSelected, m_layer, path);
+
+	if (m_style.m_mode & vertices) {
+		for (auto v = p.vertices_begin(); v != p.vertices_end(); v++) {
+			draw(*v);
+		}
+	}
 }
 
 void IpeRenderer::draw(const PolygonWithHoles<Inexact>& p) {
@@ -123,6 +168,17 @@ void IpeRenderer::draw(const PolygonWithHoles<Inexact>& p) {
 	}
 	ipe::Path* path = new ipe::Path(getAttributesForStyle(), *shape);
 	m_page->append(ipe::TSelect::ENotSelected, m_layer, path);
+
+	if (m_style.m_mode & vertices) {
+		for (auto v = p.outer_boundary().vertices_begin(); v != p.outer_boundary().vertices_end(); v++) {
+			draw(*v);
+		}
+		for (auto h = p.holes_begin(); h != p.holes_end(); h++) {
+			for (auto v = h->vertices_begin(); v != h->vertices_end(); v++) {
+				draw(*v);
+			}
+		}
+	}
 }
 
 void IpeRenderer::draw(const Circle<Inexact>& c) {
@@ -136,7 +192,7 @@ void IpeRenderer::draw(const Circle<Inexact>& c) {
 	m_page->append(ipe::TSelect::ENotSelected, m_layer, path);
 }
 
-/*void IpeRenderer::draw(const BezierSpline& s) {
+void IpeRenderer::draw(const BezierSpline& s) {
 	ipe::Curve* curve = new ipe::Curve();
 	for (BezierCurve c : s.curves()) {
 		std::vector<ipe::Vector> coords;
@@ -150,7 +206,14 @@ void IpeRenderer::draw(const Circle<Inexact>& c) {
 	shape->appendSubPath(curve);
 	ipe::Path* path = new ipe::Path(getAttributesForStyle(), *shape);
 	m_page->append(ipe::TSelect::ENotSelected, m_layer, path);
-}*/
+
+	if (m_style.m_mode & vertices) {
+		for (BezierCurve c : s.curves()) {
+			draw(c.source());
+		}
+		draw(s.curves().back().target());
+	}
+}
 
 void IpeRenderer::drawText(const Point<Inexact>& p, const std::string& text) {
 	ipe::String labelText = escapeForLaTeX(text).data();
@@ -205,6 +268,15 @@ ipe::Curve* IpeRenderer::convertPolygonToCurve(const Polygon<Inexact>& p) const 
 		                     ipe::Vector(edge->end().x(), edge->end().y()));
 	}
 	curve->setClosed(true);
+	return curve;
+}
+
+ipe::Curve* IpeRenderer::convertPolylineToCurve(const Polyline<Inexact>& p) const {
+	ipe::Curve* curve = new ipe::Curve();
+	for (auto edge = p.edges_begin(); edge != p.edges_end(); edge++) {
+		curve->appendSegment(ipe::Vector(edge->start().x(), edge->start().y()),
+		                     ipe::Vector(edge->end().x(), edge->end().y()));
+	}
 	return curve;
 }
 

--- a/cartocrow/renderer/ipe_renderer.cpp
+++ b/cartocrow/renderer/ipe_renderer.cpp
@@ -111,7 +111,10 @@ void IpeRenderer::draw(const Line<Inexact>& l) {
 	auto result = intersection(l, bounds);
 	if (result) {
 		if (const Segment<Inexact>* s = boost::get<Segment<Inexact>>(&*result)) {
+			int oldMode = m_style.m_mode;
+			setMode(oldMode & ~vertices);
 			draw(*s);
+			setMode(oldMode);
 		}
 	}
 }
@@ -122,7 +125,10 @@ void IpeRenderer::draw(const Ray<Inexact>& r) {
 	auto result = intersection(r, bounds);
 	if (result) {
 		if (const Segment<Inexact>* s = boost::get<Segment<Inexact>>(&*result)) {
+			int oldMode = m_style.m_mode;
+			setMode(oldMode & ~vertices);
 			draw(*s);
+			setMode(oldMode);
 		}
 		if (m_style.m_mode & vertices) {
 			draw(r.source());

--- a/cartocrow/renderer/ipe_renderer.cpp
+++ b/cartocrow/renderer/ipe_renderer.cpp
@@ -35,11 +35,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 namespace cartocrow::renderer {
 
 IpeRenderer::IpeRenderer(const std::shared_ptr<GeometryPainting>& painting) {
-	m_paintings.emplace_back(painting);
+	m_paintings.push_back(DrawnPainting{painting});
 }
 
 IpeRenderer::IpeRenderer(const std::shared_ptr<GeometryPainting>& painting, const std::string& name) {
-	m_paintings.emplace_back(painting, name);
+	m_paintings.push_back(DrawnPainting{painting, name});
 }
 
 void IpeRenderer::save(const std::filesystem::path& file) {
@@ -311,13 +311,13 @@ ipe::AllAttributes IpeRenderer::getAttributesForStyle() const {
 }
 
 void IpeRenderer::addPainting(const std::shared_ptr<GeometryPainting>& painting) {
-	m_paintings.emplace_back(painting);
+	m_paintings.push_back(DrawnPainting{painting});
 }
 
 void IpeRenderer::addPainting(const std::shared_ptr<GeometryPainting>& painting, const std::string& name) {
 	std::string spaceless;
 	std::replace_copy(name.begin(), name.end(), std::back_inserter(spaceless), ' ', '_');
-	m_paintings.emplace_back(painting, spaceless);
+	m_paintings.push_back(DrawnPainting{painting, spaceless});
 }
 
 std::string IpeRenderer::escapeForLaTeX(const std::string& text) const {

--- a/cartocrow/renderer/ipe_renderer.h
+++ b/cartocrow/renderer/ipe_renderer.h
@@ -71,8 +71,10 @@ struct IpeRendererStyle {
 class IpeRenderer : public GeometryRenderer {
 
   public:
+	IpeRenderer() = default;
+
 	/// Constructs a IpeRenderer for the given painting.
-	IpeRenderer(std::shared_ptr<GeometryPainting> painting);
+	IpeRenderer(const std::shared_ptr<GeometryPainting>& painting);
 
 	/// Saves the painting to an Ipe file with the given name.
 	void save(const std::filesystem::path& file);
@@ -82,7 +84,10 @@ class IpeRenderer : public GeometryRenderer {
 	void draw(const Polygon<Inexact>& p) override;
 	void draw(const PolygonWithHoles<Inexact>& p) override;
 	void draw(const Circle<Inexact>& c) override;
-	//void draw(const BezierSpline& s) override;
+	void draw(const BezierSpline& s) override;
+	void draw(const Line<Inexact>& l) override;
+	void draw(const Ray<Inexact>& r) override;
+	void draw(const Polyline<Inexact>& p) override;
 	void drawText(const Point<Inexact>& p, const std::string& text) override;
 
 	void pushStyle() override;
@@ -97,6 +102,8 @@ class IpeRenderer : public GeometryRenderer {
   private:
 	/// Converts a polygon to an Ipe curve.
 	ipe::Curve* convertPolygonToCurve(const Polygon<Inexact>& p) const;
+	/// Converts a polyline to an Ipe curve.
+	ipe::Curve* convertPolylineToCurve(const Polyline<Inexact>& p) const;
 	/// Returns Ipe attributes to style an Ipe path with the current style.
 	ipe::AllAttributes getAttributesForStyle() const;
 	/// Escapes LaTeX's [reserved characters](https://latexref.xyz/Reserved-characters.html)

--- a/cartocrow/renderer/painting_renderer.cpp
+++ b/cartocrow/renderer/painting_renderer.cpp
@@ -69,6 +69,22 @@ void PaintingRenderer::draw(const Circle<Inexact>& c) {
 	m_objects.push_back(c);
 }
 
+void PaintingRenderer::draw(const BezierSpline& s) {
+	m_objects.push_back(s);
+}
+
+void PaintingRenderer::draw(const Line<Inexact>& l) {
+	m_objects.push_back(l);
+}
+
+void PaintingRenderer::draw(const Ray<Inexact>& r) {
+	m_objects.push_back(r);
+}
+
+void PaintingRenderer::draw(const Polyline<Inexact>& p) {
+	m_objects.push_back(p);
+}
+
 void PaintingRenderer::drawText(const Point<Inexact>& p, const std::string& text) {
 	m_objects.push_back(Label(p, text));
 }

--- a/cartocrow/renderer/painting_renderer.cpp
+++ b/cartocrow/renderer/painting_renderer.cpp
@@ -37,6 +37,14 @@ void PaintingRenderer::paint(GeometryRenderer& renderer) const {
 			renderer.draw(std::get<PolygonWithHoles<Inexact>>(object));
 		} else if (std::holds_alternative<Circle<Inexact>>(object)) {
 			renderer.draw(std::get<Circle<Inexact>>(object));
+		} else if (std::holds_alternative<BezierSpline>(object)) {
+			renderer.draw(std::get<BezierSpline>(object));
+		} else if (std::holds_alternative<Line<Inexact>>(object)) {
+			renderer.draw(std::get<Line<Inexact>>(object));
+		} else if (std::holds_alternative<Ray<Inexact>>(object)) {
+			renderer.draw(std::get<Ray<Inexact>>(object));
+		} else if (std::holds_alternative<Polyline<Inexact>>(object)) {
+			renderer.draw(std::get<Polyline<Inexact>>(object));
 		} else if (std::holds_alternative<Label>(object)) {
 			renderer.drawText(std::get<Label>(object).first, std::get<Label>(object).second);
 		} else if (std::holds_alternative<Style>(object)) {

--- a/cartocrow/renderer/painting_renderer.h
+++ b/cartocrow/renderer/painting_renderer.h
@@ -41,7 +41,10 @@ class PaintingRenderer : public GeometryPainting, public GeometryRenderer {
 	void draw(const Polygon<Inexact>& p) override;
 	void draw(const PolygonWithHoles<Inexact>& p) override;
 	void draw(const Circle<Inexact>& c) override;
-	//void draw(const BezierSpline& s) override;
+	void draw(const BezierSpline& s) override;
+	void draw(const Line<Inexact>& l) override;
+	void draw(const Ray<Inexact>& r) override;
+	void draw(const Polyline<Inexact>& p) override;
 	void drawText(const Point<Inexact>& p, const std::string& text) override;
 
 	void pushStyle() override;
@@ -68,7 +71,8 @@ class PaintingRenderer : public GeometryPainting, public GeometryRenderer {
 	};
 	using Label = std::pair<Point<Inexact>, std::string>;
 	using DrawableObject = std::variant<Point<Inexact>, Segment<Inexact>, Polygon<Inexact>,
-	                                    PolygonWithHoles<Inexact>, Circle<Inexact>, Label, Style>;
+	                                    PolygonWithHoles<Inexact>, Circle<Inexact>, BezierSpline,
+	                                    Line<Inexact>, Ray<Inexact>, Polyline<Inexact>, Label, Style>;
 	std::vector<DrawableObject> m_objects;
 	Style m_style;
 };


### PR DESCRIPTION
New:
- Add polyline class (polyline.h) that acts as a wrapper around a vector of points. It provides some convenience methods like iterating over its segments. The interface is written to be similar to the CGAL::Polygon_2<K> class.
- Add `Ray<K>` alias for `CGAL::Ray_2<K>`
- Move Bézier curves and splines out of the necklace map directory into core.
- Add method to construct a Bézier curve from one control point instead of two (so a quadratic Bézier curve is transformed into a cubic one).
- Add rendering methods for polylines, rays, lines and add back those for Bézier splines. When the vertices mode is enabled, for polylines the vertices are drawn, for rays the source vertex is drawn, and for Bézier curves the endpoints are drawn, but not the control points.

Changes/fixes:
- Add rendering of the vertices of polygons when the vertices mode is enabled.
- Make first letter of the methods of bezier.h lowercase.
- Convert `approximate` methods to template functions such that they can be used with any kernel that works with `to_double`. This is useful e.g. when using `CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt`.
- Add a template function for drawing geometries that use a kernel other than Inexact.
```c++ template<class ExactGeometry>
void draw(const ExactGeometry& g) {
    draw(approximate(g));
};
```

Thoughts:
- BézierCurves are hardcoded to use the `Inexact` kernel, but we should look into allowing other kernels.
- I am wondering if the PaintingRenderer can be rewritten to have less code duplication. When adding a drawing primitive there are quite some places across files that require changes.