### PR TITLE
Add option to specify name of painting in ipe renderer.

### DIFF
--- a/cartocrow/renderer/ipe_renderer.cpp
+++ b/cartocrow/renderer/ipe_renderer.cpp
@@ -34,8 +34,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace cartocrow::renderer {
 
-IpeRenderer::IpeRenderer(std::shared_ptr<GeometryPainting> painting) {
-	m_paintings.push_back(painting);
+IpeRenderer::IpeRenderer(const std::shared_ptr<GeometryPainting>& painting) {
+	m_paintings.emplace_back(painting);
+}
+
+IpeRenderer::IpeRenderer(const std::shared_ptr<GeometryPainting>& painting, const std::string& name) {
+	m_paintings.emplace_back(painting, name);
 }
 
 void IpeRenderer::save(const std::filesystem::path& file) {
@@ -73,9 +77,13 @@ void IpeRenderer::save(const std::filesystem::path& file) {
 	m_page = new ipe::Page();
 	for (auto painting : m_paintings) {
 		pushStyle();
-		m_page->addLayer();
+		if (auto name = painting.name) {
+			m_page->addLayer(name->c_str());
+		} else {
+			m_page->addLayer();
+		}
 		m_layer = m_page->countLayers() - 1;
-		painting->paint(*this);
+		painting.m_painting->paint(*this);
 		popStyle();
 	}
 
@@ -224,8 +232,12 @@ ipe::AllAttributes IpeRenderer::getAttributesForStyle() const {
 	return attributes;
 }
 
-void IpeRenderer::addPainting(std::shared_ptr<GeometryPainting> painting) {
-	m_paintings.push_back(painting);
+void IpeRenderer::addPainting(const std::shared_ptr<GeometryPainting>& painting) {
+	m_paintings.emplace_back(painting);
+}
+
+void IpeRenderer::addPainting(const std::shared_ptr<GeometryPainting>& painting, const std::string& name) {
+	m_paintings.emplace_back(painting, name);
 }
 
 std::string IpeRenderer::escapeForLaTeX(const std::string& text) const {

--- a/cartocrow/renderer/ipe_renderer.cpp
+++ b/cartocrow/renderer/ipe_renderer.cpp
@@ -237,7 +237,9 @@ void IpeRenderer::addPainting(const std::shared_ptr<GeometryPainting>& painting)
 }
 
 void IpeRenderer::addPainting(const std::shared_ptr<GeometryPainting>& painting, const std::string& name) {
-	m_paintings.emplace_back(painting, name);
+	std::string spaceless;
+	std::replace_copy(name.begin(), name.end(), std::back_inserter(spaceless), ' ', '_');
+	m_paintings.emplace_back(painting, spaceless);
 }
 
 std::string IpeRenderer::escapeForLaTeX(const std::string& text) const {

--- a/cartocrow/renderer/ipe_renderer.h
+++ b/cartocrow/renderer/ipe_renderer.h
@@ -73,6 +73,8 @@ class IpeRenderer : public GeometryRenderer {
   public:
 	/// Constructs a IpeRenderer for the given painting.
 	IpeRenderer(std::shared_ptr<GeometryPainting> painting);
+	IpeRenderer(const std::shared_ptr<GeometryPainting>& painting);
+	IpeRenderer(const std::shared_ptr<GeometryPainting>& painting, const std::string& name);
 
 	/// Saves the painting to an Ipe file with the given name.
 	void save(const std::filesystem::path& file);
@@ -92,7 +94,8 @@ class IpeRenderer : public GeometryRenderer {
 	void setFill(Color color) override;
 	void setFillOpacity(int alpha) override;
 
-	void addPainting(std::shared_ptr<GeometryPainting> painting);
+	void addPainting(const std::shared_ptr<GeometryPainting>& painting);
+	void addPainting(const std::shared_ptr<GeometryPainting>& painting, const std::string& name);
 
   private:
 	/// Converts a polygon to an Ipe curve.
@@ -104,8 +107,15 @@ class IpeRenderer : public GeometryRenderer {
 	/// an Ipe file.
 	std::string escapeForLaTeX(const std::string& text) const;
 
+	struct DrawnPainting {
+		/// The painting itself.
+		std::shared_ptr<GeometryPainting> m_painting;
+		/// The name of the painting displayed as a layer name in ipe.
+		std::optional<std::string> name;
+	};
+
 	/// The paintings we're drawing.
-	std::vector<std::shared_ptr<GeometryPainting>> m_paintings;
+	std::vector<DrawnPainting> m_paintings;
 	/// The current drawing style.
 	IpeRendererStyle m_style;
 	/// A stack of drawing styles, used by \ref pushStyle() and \ref popStyle()

--- a/cartocrow/renderer/ipe_renderer.h
+++ b/cartocrow/renderer/ipe_renderer.h
@@ -72,7 +72,6 @@ class IpeRenderer : public GeometryRenderer {
 
   public:
 	/// Constructs a IpeRenderer for the given painting.
-	IpeRenderer(std::shared_ptr<GeometryPainting> painting);
 	IpeRenderer(const std::shared_ptr<GeometryPainting>& painting);
 	IpeRenderer(const std::shared_ptr<GeometryPainting>& painting, const std::string& name);
 


### PR DESCRIPTION
Ipe does not like spaces in layer names and the `addLayer` method does not automatically replace them with underscores, so I do this manually.