### PR TITLE
Avoid glog vs. Catch2 conflicts

### DIFF
--- a/cartocrow/core/centroid.h
+++ b/cartocrow/core/centroid.h
@@ -26,7 +26,6 @@ Created by tvl (t.vanlankveld@esciencecenter.nl) on 05-12-2019
 
 #include <CGAL/Kernel/global_functions_2.h>
 #include <CGAL/Origin.h>
-#include <glog/logging.h>
 #include <numeric>
 #include <stdexcept>
 

--- a/cartocrow/flow_map/intersections.cpp
+++ b/cartocrow/flow_map/intersections.cpp
@@ -21,8 +21,6 @@ Created by tvl (t.vanlankveld@esciencecenter.nl) on 26-02-2021
 
 #include "intersections.h"
 
-#include <glog/logging.h>
-
 namespace cartocrow::flow_map {
 namespace detail {
 
@@ -136,9 +134,9 @@ void intersect(const Spiral& spiral_1, const Spiral& spiral_2,
 	// remember that the spirals have an infinite number of intersections;
 	// we want the one farthest from the pole for which 0 < t
 	const Number<Inexact> t_1_positive = 0 < ddt_phi ? d_phi / ddt_phi : (d_phi - M_2xPI) / ddt_phi;
-	CHECK_LT(0, t_1_positive);
+	//CHECK_LT(0, t_1_positive);
 	//CHECK_LE(t_1, std::abs(M_PI / tan_alpha_1));
-	CHECK_LT(t_1_positive, t_period);
+	//CHECK_LT(t_1_positive, t_period);
 
 	intersections.push_back(spiral_1.evaluate(t_1_positive));
 	intersections.push_back(spiral_1.evaluate(t_1_positive - t_period));

--- a/cartocrow/simplification/vw_simplification.cpp
+++ b/cartocrow/simplification/vw_simplification.cpp
@@ -20,8 +20,6 @@ Created by Wouter Meulemans (w.meulemans@tue.nl) on 31-08-2021
 
 #include "vw_simplification.h"
 
-#include <glog/logging.h>
-
 namespace cartocrow::vw_simplification {
 
 VWSimplification::VWSimplification(std::shared_ptr<std::vector<Point<Exact>>> pts) {


### PR DESCRIPTION
Catch2 conflicts with glog, which causes compilation errors. Files used (directly or indirectly) by unit tests should not include glog.

In the long term I'd like to phase out glog entirely.