### PR TITLE
Implement paths for rendering

### DIFF
--- a/cartocrow/renderer/CMakeLists.txt
+++ b/cartocrow/renderer/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
 	geometry_widget.cpp
 	ipe_renderer.cpp
 	painting_renderer.cpp
+	render_path.cpp
 )
 set(HEADERS
 	geometry_painting.h
@@ -10,6 +11,7 @@ set(HEADERS
 	geometry_widget.h
 	ipe_renderer.h
 	painting_renderer.h
+	render_path.h
 )
 
 add_library(renderer ${SOURCES})

--- a/cartocrow/renderer/geometry_renderer.cpp
+++ b/cartocrow/renderer/geometry_renderer.cpp
@@ -23,10 +23,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 namespace cartocrow::renderer {
 
 void GeometryRenderer::draw(const Segment<Inexact>& s) {
-	RenderPath p;
-	p.moveTo(s.start());
-	p.lineTo(s.end());
-	draw(p);
+	RenderPath path;
+	path.moveTo(s.start());
+	path.lineTo(s.end());
+	draw(path);
+}
+
+void GeometryRenderer::draw(const Polygon<Inexact>& p) {
+	RenderPath path;
+	for (auto vertex = p.vertices_begin(); vertex != p.vertices_end(); vertex++) {
+		if (vertex == p.vertices_begin()) {
+			path.moveTo(*vertex);
+		} else {
+			path.lineTo(*vertex);
+		}
+	}
+	path.close();
+	draw(path);
 }
 
 void GeometryRenderer::draw(const PolygonSet<Inexact>& ps) {

--- a/cartocrow/renderer/geometry_renderer.cpp
+++ b/cartocrow/renderer/geometry_renderer.cpp
@@ -22,6 +22,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace cartocrow::renderer {
 
+void GeometryRenderer::draw(const Segment<Inexact>& s) {
+	RenderPath p;
+	p.moveTo(s.start());
+	p.lineTo(s.end());
+	draw(p);
+}
+
 void GeometryRenderer::draw(const PolygonSet<Inexact>& ps) {
 	std::vector<PolygonWithHoles<Inexact>> polygons;
 	ps.polygons_with_holes(std::back_inserter(polygons));

--- a/cartocrow/renderer/geometry_renderer.cpp
+++ b/cartocrow/renderer/geometry_renderer.cpp
@@ -42,6 +42,18 @@ void GeometryRenderer::draw(const Polygon<Inexact>& p) {
 	draw(path);
 }
 
+void GeometryRenderer::draw(const Polyline<Inexact>& p) {
+	RenderPath path;
+	for (auto vertex = p.vertices_begin(); vertex != p.vertices_end(); vertex++) {
+		if (vertex == p.vertices_begin()) {
+			path.moveTo(*vertex);
+		} else {
+			path.lineTo(*vertex);
+		}
+	}
+	draw(path);
+}
+
 void GeometryRenderer::draw(const PolygonSet<Inexact>& ps) {
 	std::vector<PolygonWithHoles<Inexact>> polygons;
 	ps.polygons_with_holes(std::back_inserter(polygons));

--- a/cartocrow/renderer/geometry_renderer.h
+++ b/cartocrow/renderer/geometry_renderer.h
@@ -22,8 +22,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../core/bezier.h"
 #include "../core/core.h"
-#include "../core/region_map.h"
 #include "../core/polyline.h"
+#include "render_path.h"
 
 namespace cartocrow::renderer {
 
@@ -108,6 +108,8 @@ class GeometryRenderer {
 	virtual void draw(const Ray<Inexact>& r) = 0;
 	/// Draws a polyline with the currently set style.
 	virtual void draw(const Polyline<Inexact>& p) = 0;
+	/// Draws a \ref RenderPath with the currently set style.
+	virtual void draw(const RenderPath& p) = 0;
 
 	/// Draws an exact geometry with the currently set style by approximating it.
 	template<class ExactGeometry>

--- a/cartocrow/renderer/geometry_renderer.h
+++ b/cartocrow/renderer/geometry_renderer.h
@@ -91,7 +91,7 @@ class GeometryRenderer {
 	/// Draws a single line segment with the currently set style.
 	void draw(const Segment<Inexact>& s);
 	/// Draws a simple polygon with the currently set style.
-	virtual void draw(const Polygon<Inexact>& p) = 0;
+	void draw(const Polygon<Inexact>& p);
 	/// Draws a polygon with holes with the currently set style.
 	virtual void draw(const PolygonWithHoles<Inexact>& p) = 0;
 	/// Draws a circle with the currently set style.

--- a/cartocrow/renderer/geometry_renderer.h
+++ b/cartocrow/renderer/geometry_renderer.h
@@ -92,6 +92,8 @@ class GeometryRenderer {
 	void draw(const Segment<Inexact>& s);
 	/// Draws a simple polygon with the currently set style.
 	void draw(const Polygon<Inexact>& p);
+	/// Draws a polyline with the currently set style.
+	void draw(const Polyline<Inexact>& p);
 	/// Draws a polygon with holes with the currently set style.
 	virtual void draw(const PolygonWithHoles<Inexact>& p) = 0;
 	/// Draws a circle with the currently set style.
@@ -106,8 +108,6 @@ class GeometryRenderer {
 	virtual void draw(const Line<Inexact>& l) = 0;
 	/// Draws a ray with the currently set style.
 	virtual void draw(const Ray<Inexact>& r) = 0;
-	/// Draws a polyline with the currently set style.
-	virtual void draw(const Polyline<Inexact>& p) = 0;
 	/// Draws a \ref RenderPath with the currently set style.
 	virtual void draw(const RenderPath& p) = 0;
 

--- a/cartocrow/renderer/geometry_renderer.h
+++ b/cartocrow/renderer/geometry_renderer.h
@@ -89,14 +89,14 @@ class GeometryRenderer {
 	/// Draws a single point with the currently set style.
 	virtual void draw(const Point<Inexact>& p) = 0;
 	/// Draws a single line segment with the currently set style.
-	virtual void draw(const Segment<Inexact>& s) = 0;
+	void draw(const Segment<Inexact>& s);
 	/// Draws a simple polygon with the currently set style.
 	virtual void draw(const Polygon<Inexact>& p) = 0;
 	/// Draws a polygon with holes with the currently set style.
 	virtual void draw(const PolygonWithHoles<Inexact>& p) = 0;
 	/// Draws a circle with the currently set style.
 	virtual void draw(const Circle<Inexact>& c) = 0;
-	/// Draws a Bézier spline with the currently set style.
+	/// Draws a Bézier curve with the currently set style.
 	void draw(const BezierCurve& c);
 	/// Draws a Bézier spline with the currently set style.
 	virtual void draw(const BezierSpline& s) = 0;

--- a/cartocrow/renderer/geometry_widget.cpp
+++ b/cartocrow/renderer/geometry_widget.cpp
@@ -596,6 +596,21 @@ void GeometryWidget::draw(const Polyline<Inexact>& p) {
 	}
 }
 
+void GeometryWidget::draw(const RenderPath& p) {
+	setupPainter();
+	QPainterPath path;
+	for (RenderPath::Command c : p.commands()) {
+		if (std::holds_alternative<RenderPath::MoveTo>(c)) {
+			path.moveTo(convertPoint(std::get<RenderPath::MoveTo>(c).m_to));
+		} else if (std::holds_alternative<RenderPath::LineTo>(c)) {
+			path.lineTo(convertPoint(std::get<RenderPath::LineTo>(c).m_to));
+		} else if (std::holds_alternative<RenderPath::Close>(c)) {
+			path.closeSubpath();
+		}
+	}
+	m_painter->drawPath(path);
+}
+
 void GeometryWidget::drawText(const Point<Inexact>& p, const std::string& text) {
 	setupPainter();
 	QPointF p2 = convertPoint(p);

--- a/cartocrow/renderer/geometry_widget.cpp
+++ b/cartocrow/renderer/geometry_widget.cpp
@@ -20,7 +20,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "geometry_widget.h"
 
 #include "geometry_renderer.h"
+#include "ipe_renderer.h"
 
+#include <QFileDialog>
 #include <QGuiApplication>
 #include <QPainterPath>
 #include <QPen>
@@ -144,6 +146,11 @@ GeometryWidget::GeometryWidget() {
 	m_zoomInButton->setText("+");
 	connect(m_zoomInButton, &QToolButton::clicked, this, &GeometryWidget::zoomIn);
 	m_zoomBar->addWidget(m_zoomInButton);
+	m_zoomBar->addSeparator();
+	m_saveToIpeButton = new QToolButton(m_zoomBar);
+	m_saveToIpeButton->setText("Save");
+	connect(m_saveToIpeButton, &QToolButton::clicked, this, &GeometryWidget::saveToIpe);
+	m_zoomBar->addWidget(m_saveToIpeButton);
 }
 
 GeometryWidget::GeometryWidget(std::shared_ptr<GeometryPainting> painting) : GeometryWidget() {
@@ -732,6 +739,19 @@ void GeometryWidget::fitInView(Box bbox) {
 void GeometryWidget::setGridMode(GridMode mode) {
 	m_gridMode = mode;
 	update();
+}
+
+void GeometryWidget::saveToIpe() {
+	QString fileName = QFileDialog::getSaveFileName(this, "Save drawing", ".", "Ipe XML files (.xml)");
+	if (fileName == nullptr) {
+		return;
+	}
+
+	IpeRenderer renderer;
+	for (const DrawnPainting& painting : m_paintings) {
+		renderer.addPainting(painting.m_painting, painting.name);
+	}
+	renderer.save(fileName.toStdString());
 }
 
 } // namespace cartocrow::renderer

--- a/cartocrow/renderer/geometry_widget.cpp
+++ b/cartocrow/renderer/geometry_widget.cpp
@@ -742,7 +742,7 @@ void GeometryWidget::setGridMode(GridMode mode) {
 }
 
 void GeometryWidget::saveToIpe() {
-	QString fileName = QFileDialog::getSaveFileName(this, "Save drawing", ".", "Ipe XML files (*.xml)");
+	QString fileName = QFileDialog::getSaveFileName(this, "Save drawing", ".", "Ipe XML files (*.ipe)");
 	if (fileName == nullptr) {
 		return;
 	}

--- a/cartocrow/renderer/geometry_widget.cpp
+++ b/cartocrow/renderer/geometry_widget.cpp
@@ -742,7 +742,7 @@ void GeometryWidget::setGridMode(GridMode mode) {
 }
 
 void GeometryWidget::saveToIpe() {
-	QString fileName = QFileDialog::getSaveFileName(this, "Save drawing", ".", "Ipe XML files (.xml)");
+	QString fileName = QFileDialog::getSaveFileName(this, "Save drawing", ".", "Ipe XML files (*.xml)");
 	if (fileName == nullptr) {
 		return;
 	}

--- a/cartocrow/renderer/geometry_widget.cpp
+++ b/cartocrow/renderer/geometry_widget.cpp
@@ -478,18 +478,6 @@ void GeometryWidget::draw(const Point<Inexact>& p) {
 	                              m_style.m_pointSize));
 }
 
-void GeometryWidget::draw(const Polygon<Inexact>& p) {
-	setupPainter();
-	QPainterPath path;
-	addPolygonToPath(path, p);
-	m_painter->drawPath(path);
-	if (m_style.m_mode & vertices) {
-		for (auto v = p.vertices_begin(); v != p.vertices_end(); v++) {
-			draw(*v);
-		}
-	}
-}
-
 void GeometryWidget::draw(const PolygonWithHoles<Inexact>& p) {
 	setupPainter();
 	QPainterPath path;

--- a/cartocrow/renderer/geometry_widget.cpp
+++ b/cartocrow/renderer/geometry_widget.cpp
@@ -570,21 +570,6 @@ void GeometryWidget::draw(const Line<Inexact>& l) {
 	}
 }
 
-void GeometryWidget::draw(const Polyline<Inexact>& p) {
-	setupPainter();
-	QPainterPath path;
-	path.moveTo(convertPoint(*p.vertices_begin()));
-	for (auto v = p.vertices_begin()++; v != p.vertices_end(); v++) {
-		path.lineTo(convertPoint(*v));
-	}
-	m_painter->drawPath(path);
-	if (m_style.m_mode & vertices) {
-		for (auto v = p.vertices_begin(); v != p.vertices_end(); v++) {
-			draw(*v);
-		}
-	}
-}
-
 void GeometryWidget::draw(const RenderPath& p) {
 	setupPainter();
 	QPainterPath path;

--- a/cartocrow/renderer/geometry_widget.cpp
+++ b/cartocrow/renderer/geometry_widget.cpp
@@ -704,7 +704,7 @@ void GeometryWidget::zoomIn() {
 void GeometryWidget::zoomOut() {
 	m_transform /= 1.5;
 	if (m_transform.m11() < m_minZoom) {
-		m_transform /= m_minZoom / m_transform.m11();
+		m_transform *= m_minZoom / m_transform.m11();
 	}
 	updateZoomSlider();
 	update();

--- a/cartocrow/renderer/geometry_widget.cpp
+++ b/cartocrow/renderer/geometry_widget.cpp
@@ -320,26 +320,28 @@ void GeometryWidget::drawAxes() {
 		double minorTint = tickScale - floor(tickScale);
 		int minorColor = 255 - 64 * minorTint;
 		setStroke(Color{minorColor, minorColor, minorColor}, 1);
-		for (int i = floor(bounds.xmin() / (majorScale / 10)); i <= bounds.xmax() / (majorScale / 10);
-			++i) {
-			draw(Segment<Inexact>(Point<Inexact>(i * majorScale / 10, bounds.ymin()),
-								Point<Inexact>(i * majorScale / 10, bounds.ymax())));
+		for (int i = floor(bounds.xmin() / (majorScale / 10));
+		     i <= bounds.xmax() / (majorScale / 10); ++i) {
+			GeometryRenderer::draw(
+			    Segment<Inexact>(Point<Inexact>(i * majorScale / 10, bounds.ymin()),
+			                     Point<Inexact>(i * majorScale / 10, bounds.ymax())));
 		}
-		for (int i = floor(bounds.ymax() / (majorScale / 10)); i <= bounds.ymin() / (majorScale / 10);
-			++i) {
-			draw(Segment<Inexact>(Point<Inexact>(bounds.xmin(), i * majorScale / 10),
-								Point<Inexact>(bounds.xmax(), i * majorScale / 10)));
+		for (int i = floor(bounds.ymax() / (majorScale / 10));
+		     i <= bounds.ymin() / (majorScale / 10); ++i) {
+			GeometryRenderer::draw(
+			    Segment<Inexact>(Point<Inexact>(bounds.xmin(), i * majorScale / 10),
+			                     Point<Inexact>(bounds.xmax(), i * majorScale / 10)));
 		}
 
 		// major grid lines
 		setStroke(Color{192, 192, 192}, 1);
 		for (int i = floor(bounds.xmin() / majorScale); i <= bounds.xmax() / majorScale; ++i) {
-			draw(Segment<Inexact>(Point<Inexact>(i * majorScale, bounds.ymin()),
-								Point<Inexact>(i * majorScale, bounds.ymax())));
+			GeometryRenderer::draw(Segment<Inexact>(Point<Inexact>(i * majorScale, bounds.ymin()),
+			                                        Point<Inexact>(i * majorScale, bounds.ymax())));
 		}
 		for (int i = floor(bounds.ymax() / majorScale); i <= bounds.ymin() / majorScale; ++i) {
-			draw(Segment<Inexact>(Point<Inexact>(bounds.xmin(), i * majorScale),
-								Point<Inexact>(bounds.xmax(), i * majorScale)));
+			GeometryRenderer::draw(Segment<Inexact>(Point<Inexact>(bounds.xmin(), i * majorScale),
+			                                        Point<Inexact>(bounds.xmax(), i * majorScale)));
 		}
 
 	} else if (m_gridMode == GridMode::POLAR) {
@@ -380,8 +382,10 @@ void GeometryWidget::drawAxes() {
 
 	// axes
 	setStroke(Color{150, 150, 150}, 1.8);
-	draw(Segment<Inexact>(Point<Inexact>(bounds.xmin(), 0), Point<Inexact>(bounds.xmax(), 0)));
-	draw(Segment<Inexact>(Point<Inexact>(0, bounds.ymin()), Point<Inexact>(0, bounds.ymax())));
+	GeometryRenderer::draw(
+	    Segment<Inexact>(Point<Inexact>(bounds.xmin(), 0), Point<Inexact>(bounds.xmax(), 0)));
+	GeometryRenderer::draw(
+	    Segment<Inexact>(Point<Inexact>(0, bounds.ymin()), Point<Inexact>(0, bounds.ymax())));
 
 	// labels
 	QPointF origin = convertPoint(Point<Inexact>(0, 0));
@@ -474,18 +478,6 @@ void GeometryWidget::draw(const Point<Inexact>& p) {
 	                              m_style.m_pointSize));
 }
 
-void GeometryWidget::draw(const Segment<Inexact>& s) {
-	setupPainter();
-	QPointF p1 = convertPoint(s.start());
-	QPointF p2 = convertPoint(s.end());
-	m_painter->drawLine(p1, p2);
-
-	if (m_style.m_mode & vertices) {
-		draw(s.start());
-		draw(s.end());
-	}
-}
-
 void GeometryWidget::draw(const Polygon<Inexact>& p) {
 	setupPainter();
 	QPainterPath path;
@@ -559,7 +551,7 @@ void GeometryWidget::draw(const Ray<Inexact>& r) {
 		if (const Segment<Inexact>* s = boost::get<Segment<Inexact>>(&*result)) {
 			int oldMode = m_style.m_mode;
 			setMode(oldMode & ~vertices);
-			draw(*s);
+			GeometryRenderer::draw(*s);
 			setMode(oldMode);
 		}
 		if (m_style.m_mode & vertices) {
@@ -570,12 +562,14 @@ void GeometryWidget::draw(const Ray<Inexact>& r) {
 
 void GeometryWidget::draw(const Line<Inexact>& l) {
 	Box bounds = inverseConvertBox(rect());
-	auto result = intersection(l, CGAL::Iso_rectangle_2<Inexact>(Point<Inexact>(bounds.xmin(), bounds.ymin()), Point<Inexact>(bounds.xmax(), bounds.ymax())));
+	auto result =
+	    intersection(l, CGAL::Iso_rectangle_2<Inexact>(Point<Inexact>(bounds.xmin(), bounds.ymin()),
+	                                                   Point<Inexact>(bounds.xmax(), bounds.ymax())));
 	if (result) {
 		if (const Segment<Inexact>* s = boost::get<Segment<Inexact>>(&*result)) {
 			int oldMode = m_style.m_mode;
 			setMode(oldMode & ~vertices);
-			draw(*s);
+			GeometryRenderer::draw(*s);
 			setMode(oldMode);
 		}
 	}
@@ -599,16 +593,26 @@ void GeometryWidget::draw(const Polyline<Inexact>& p) {
 void GeometryWidget::draw(const RenderPath& p) {
 	setupPainter();
 	QPainterPath path;
+	std::vector<Point<Inexact>> verticesToDraw;
 	for (RenderPath::Command c : p.commands()) {
 		if (std::holds_alternative<RenderPath::MoveTo>(c)) {
-			path.moveTo(convertPoint(std::get<RenderPath::MoveTo>(c).m_to));
+			Point<Inexact> to = std::get<RenderPath::MoveTo>(c).m_to;
+			verticesToDraw.push_back(to);
+			path.moveTo(convertPoint(to));
 		} else if (std::holds_alternative<RenderPath::LineTo>(c)) {
+			Point<Inexact> to = std::get<RenderPath::LineTo>(c).m_to;
+			verticesToDraw.push_back(to);
 			path.lineTo(convertPoint(std::get<RenderPath::LineTo>(c).m_to));
 		} else if (std::holds_alternative<RenderPath::Close>(c)) {
 			path.closeSubpath();
 		}
 	}
 	m_painter->drawPath(path);
+	if (m_style.m_mode & vertices) {
+		for (const Point<Inexact>& vertex : verticesToDraw) {
+			draw(vertex);
+		}
+	}
 }
 
 void GeometryWidget::drawText(const Point<Inexact>& p, const std::string& text) {

--- a/cartocrow/renderer/geometry_widget.h
+++ b/cartocrow/renderer/geometry_widget.h
@@ -167,7 +167,6 @@ class GeometryWidget : public QWidget, public GeometryRenderer {
 	void draw(const BezierSpline& s) override;
 	void draw(const Line<Inexact>& l) override;
 	void draw(const Ray<Inexact>& r) override;
-	void draw(const Polyline<Inexact>& p) override;
 	void draw(const RenderPath& p) override;
 	void drawText(const Point<Inexact>& p, const std::string& text) override;
 

--- a/cartocrow/renderer/geometry_widget.h
+++ b/cartocrow/renderer/geometry_widget.h
@@ -162,7 +162,6 @@ class GeometryWidget : public QWidget, public GeometryRenderer {
 	GeometryWidget(std::shared_ptr<GeometryPainting> painting);
 
 	void draw(const Point<Inexact>& p) override;
-	void draw(const Polygon<Inexact>& p) override;
 	void draw(const PolygonWithHoles<Inexact>& p) override;
 	void draw(const Circle<Inexact>& c) override;
 	void draw(const BezierSpline& s) override;

--- a/cartocrow/renderer/geometry_widget.h
+++ b/cartocrow/renderer/geometry_widget.h
@@ -212,6 +212,9 @@ class GeometryWidget : public QWidget, public GeometryRenderer {
 	void fitInView(Box bbox);
 	/// Sets the type of grid.
 	void setGridMode(GridMode mode);
+	/// Launches a file picker that allows the user to save the drawing to an
+	/// Ipe file.
+	void saveToIpe();
 
   signals:
 	/// Emitted when the user clicks on the widget.
@@ -320,6 +323,8 @@ class GeometryWidget : public QWidget, public GeometryRenderer {
 	QSlider* m_zoomSlider;
 	/// The zoom in button in the toolbar.
 	QToolButton* m_zoomInButton;
+	/// The save to Ipe button in the toolbar.
+	QToolButton* m_saveToIpeButton;
 };
 
 } // namespace cartocrow::renderer

--- a/cartocrow/renderer/geometry_widget.h
+++ b/cartocrow/renderer/geometry_widget.h
@@ -170,6 +170,7 @@ class GeometryWidget : public QWidget, public GeometryRenderer {
 	void draw(const Line<Inexact>& l) override;
 	void draw(const Ray<Inexact>& r) override;
 	void draw(const Polyline<Inexact>& p) override;
+	void draw(const RenderPath& p) override;
 	void drawText(const Point<Inexact>& p, const std::string& text) override;
 
 	void pushStyle() override;

--- a/cartocrow/renderer/geometry_widget.h
+++ b/cartocrow/renderer/geometry_widget.h
@@ -162,7 +162,6 @@ class GeometryWidget : public QWidget, public GeometryRenderer {
 	GeometryWidget(std::shared_ptr<GeometryPainting> painting);
 
 	void draw(const Point<Inexact>& p) override;
-	void draw(const Segment<Inexact>& s) override;
 	void draw(const Polygon<Inexact>& p) override;
 	void draw(const PolygonWithHoles<Inexact>& p) override;
 	void draw(const Circle<Inexact>& c) override;

--- a/cartocrow/renderer/ipe_renderer.cpp
+++ b/cartocrow/renderer/ipe_renderer.cpp
@@ -99,21 +99,6 @@ void IpeRenderer::draw(const Point<Inexact>& p) {
 	m_page->append(ipe::TSelect::ENotSelected, m_layer, reference);
 }
 
-void IpeRenderer::draw(const Segment<Inexact>& s) {
-	ipe::Curve* curve = new ipe::Curve();
-	curve->appendSegment(ipe::Vector(s.start().x(), s.start().y()),
-	                     ipe::Vector(s.end().x(), s.end().y()));
-	ipe::Shape* shape = new ipe::Shape();
-	shape->appendSubPath(curve);
-	ipe::Path* path = new ipe::Path(getAttributesForStyle(), *shape);
-	m_page->append(ipe::TSelect::ENotSelected, m_layer, path);
-
-	if (m_style.m_mode & vertices) {
-		draw(s.start());
-		draw(s.end());
-	}
-}
-
 void IpeRenderer::draw(const Line<Inexact>& l) {
 	// Crop to document size
 	auto bounds = CGAL::Iso_rectangle_2<Inexact>(CGAL::ORIGIN, Point<Inexact>(1000.0, 1000.0));
@@ -122,7 +107,7 @@ void IpeRenderer::draw(const Line<Inexact>& l) {
 		if (const Segment<Inexact>* s = boost::get<Segment<Inexact>>(&*result)) {
 			int oldMode = m_style.m_mode;
 			setMode(oldMode & ~vertices);
-			draw(*s);
+			GeometryRenderer::draw(*s);
 			setMode(oldMode);
 		}
 	}
@@ -136,7 +121,7 @@ void IpeRenderer::draw(const Ray<Inexact>& r) {
 		if (const Segment<Inexact>* s = boost::get<Segment<Inexact>>(&*result)) {
 			int oldMode = m_style.m_mode;
 			setMode(oldMode & ~vertices);
-			draw(*s);
+			GeometryRenderer::draw(*s);
 			setMode(oldMode);
 		}
 		if (m_style.m_mode & vertices) {

--- a/cartocrow/renderer/ipe_renderer.cpp
+++ b/cartocrow/renderer/ipe_renderer.cpp
@@ -144,20 +144,6 @@ void IpeRenderer::draw(const Polyline<Inexact>& p) {
 	}
 }
 
-void IpeRenderer::draw(const Polygon<Inexact>& p) {
-	ipe::Curve* curve = convertPolygonToCurve(p);
-	ipe::Shape* shape = new ipe::Shape();
-	shape->appendSubPath(curve);
-	ipe::Path* path = new ipe::Path(getAttributesForStyle(), *shape);
-	m_page->append(ipe::TSelect::ENotSelected, m_layer, path);
-
-	if (m_style.m_mode & vertices) {
-		for (auto v = p.vertices_begin(); v != p.vertices_end(); v++) {
-			draw(*v);
-		}
-	}
-}
-
 void IpeRenderer::draw(const PolygonWithHoles<Inexact>& p) {
 	ipe::Curve* curve = convertPolygonToCurve(p.outer_boundary());
 	ipe::Shape* shape = new ipe::Shape();

--- a/cartocrow/renderer/ipe_renderer.cpp
+++ b/cartocrow/renderer/ipe_renderer.cpp
@@ -130,20 +130,6 @@ void IpeRenderer::draw(const Ray<Inexact>& r) {
 	}
 }
 
-void IpeRenderer::draw(const Polyline<Inexact>& p) {
-	ipe::Curve* curve = convertPolylineToCurve(p);
-	ipe::Shape* shape = new ipe::Shape();
-	shape->appendSubPath(curve);
-	ipe::Path* path = new ipe::Path(getAttributesForStyle(), *shape);
-	m_page->append(ipe::TSelect::ENotSelected, m_layer, path);
-
-	if (m_style.m_mode & vertices) {
-		for (auto v = p.vertices_begin(); v != p.vertices_end(); v++) {
-			draw(*v);
-		}
-	}
-}
-
 void IpeRenderer::draw(const PolygonWithHoles<Inexact>& p) {
 	ipe::Curve* curve = convertPolygonToCurve(p.outer_boundary());
 	ipe::Shape* shape = new ipe::Shape();
@@ -306,15 +292,6 @@ ipe::Curve* IpeRenderer::convertPolygonToCurve(const Polygon<Inexact>& p) const 
 		                     ipe::Vector(edge->end().x(), edge->end().y()));
 	}
 	curve->setClosed(true);
-	return curve;
-}
-
-ipe::Curve* IpeRenderer::convertPolylineToCurve(const Polyline<Inexact>& p) const {
-	ipe::Curve* curve = new ipe::Curve();
-	for (auto edge = p.edges_begin(); edge != p.edges_end(); edge++) {
-		curve->appendSegment(ipe::Vector(edge->start().x(), edge->start().y()),
-		                     ipe::Vector(edge->end().x(), edge->end().y()));
-	}
 	return curve;
 }
 

--- a/cartocrow/renderer/ipe_renderer.cpp
+++ b/cartocrow/renderer/ipe_renderer.cpp
@@ -230,6 +230,11 @@ void IpeRenderer::draw(const BezierSpline& s) {
 	}
 }
 
+void IpeRenderer::draw(const RenderPath& p) {
+	/*ipe::Curve* curve = convertPolylineToCurve(p);*/
+	// TODO
+}
+
 void IpeRenderer::drawText(const Point<Inexact>& p, const std::string& text) {
 	ipe::String labelText = escapeForLaTeX(text).data();
 	ipe::Text* label = new ipe::Text(getAttributesForStyle(), labelText,

--- a/cartocrow/renderer/ipe_renderer.h
+++ b/cartocrow/renderer/ipe_renderer.h
@@ -90,6 +90,7 @@ class IpeRenderer : public GeometryRenderer {
 	void draw(const Line<Inexact>& l) override;
 	void draw(const Ray<Inexact>& r) override;
 	void draw(const Polyline<Inexact>& p) override;
+	void draw(const RenderPath& p) override;
 	void drawText(const Point<Inexact>& p, const std::string& text) override;
 
 	void pushStyle() override;

--- a/cartocrow/renderer/ipe_renderer.h
+++ b/cartocrow/renderer/ipe_renderer.h
@@ -82,7 +82,6 @@ class IpeRenderer : public GeometryRenderer {
 	void save(const std::filesystem::path& file);
 
 	void draw(const Point<Inexact>& p) override;
-	void draw(const Segment<Inexact>& s) override;
 	void draw(const Polygon<Inexact>& p) override;
 	void draw(const PolygonWithHoles<Inexact>& p) override;
 	void draw(const Circle<Inexact>& c) override;

--- a/cartocrow/renderer/ipe_renderer.h
+++ b/cartocrow/renderer/ipe_renderer.h
@@ -87,7 +87,6 @@ class IpeRenderer : public GeometryRenderer {
 	void draw(const BezierSpline& s) override;
 	void draw(const Line<Inexact>& l) override;
 	void draw(const Ray<Inexact>& r) override;
-	void draw(const Polyline<Inexact>& p) override;
 	void draw(const RenderPath& p) override;
 	void drawText(const Point<Inexact>& p, const std::string& text) override;
 
@@ -105,8 +104,6 @@ class IpeRenderer : public GeometryRenderer {
   private:
 	/// Converts a polygon to an Ipe curve.
 	ipe::Curve* convertPolygonToCurve(const Polygon<Inexact>& p) const;
-	/// Converts a polyline to an Ipe curve.
-	ipe::Curve* convertPolylineToCurve(const Polyline<Inexact>& p) const;
 	/// Returns Ipe attributes to style an Ipe path with the current style.
 	ipe::AllAttributes getAttributesForStyle() const;
 	/// Escapes LaTeX's [reserved characters](https://latexref.xyz/Reserved-characters.html)

--- a/cartocrow/renderer/ipe_renderer.h
+++ b/cartocrow/renderer/ipe_renderer.h
@@ -82,7 +82,6 @@ class IpeRenderer : public GeometryRenderer {
 	void save(const std::filesystem::path& file);
 
 	void draw(const Point<Inexact>& p) override;
-	void draw(const Polygon<Inexact>& p) override;
 	void draw(const PolygonWithHoles<Inexact>& p) override;
 	void draw(const Circle<Inexact>& c) override;
 	void draw(const BezierSpline& s) override;

--- a/cartocrow/renderer/painting_renderer.cpp
+++ b/cartocrow/renderer/painting_renderer.cpp
@@ -29,8 +29,6 @@ void PaintingRenderer::paint(GeometryRenderer& renderer) const {
 	for (auto& object : m_objects) {
 		if (std::holds_alternative<Point<Inexact>>(object)) {
 			renderer.draw(std::get<Point<Inexact>>(object));
-		} else if (std::holds_alternative<Polygon<Inexact>>(object)) {
-			renderer.draw(std::get<Polygon<Inexact>>(object));
 		} else if (std::holds_alternative<PolygonWithHoles<Inexact>>(object)) {
 			renderer.draw(std::get<PolygonWithHoles<Inexact>>(object));
 		} else if (std::holds_alternative<Circle<Inexact>>(object)) {
@@ -58,10 +56,6 @@ void PaintingRenderer::paint(GeometryRenderer& renderer) const {
 }
 
 void PaintingRenderer::draw(const Point<Inexact>& p) {
-	m_objects.push_back(p);
-}
-
-void PaintingRenderer::draw(const Polygon<Inexact>& p) {
 	m_objects.push_back(p);
 }
 

--- a/cartocrow/renderer/painting_renderer.cpp
+++ b/cartocrow/renderer/painting_renderer.cpp
@@ -39,8 +39,6 @@ void PaintingRenderer::paint(GeometryRenderer& renderer) const {
 			renderer.draw(std::get<Line<Inexact>>(object));
 		} else if (std::holds_alternative<Ray<Inexact>>(object)) {
 			renderer.draw(std::get<Ray<Inexact>>(object));
-		} else if (std::holds_alternative<Polyline<Inexact>>(object)) {
-			renderer.draw(std::get<Polyline<Inexact>>(object));
 		} else if (std::holds_alternative<RenderPath>(object)) {
 			renderer.draw(std::get<RenderPath>(object));
 		} else if (std::holds_alternative<Label>(object)) {
@@ -77,10 +75,6 @@ void PaintingRenderer::draw(const Line<Inexact>& l) {
 
 void PaintingRenderer::draw(const Ray<Inexact>& r) {
 	m_objects.push_back(r);
-}
-
-void PaintingRenderer::draw(const Polyline<Inexact>& p) {
-	m_objects.push_back(p);
 }
 
 void PaintingRenderer::draw(const RenderPath& p) {

--- a/cartocrow/renderer/painting_renderer.cpp
+++ b/cartocrow/renderer/painting_renderer.cpp
@@ -45,6 +45,8 @@ void PaintingRenderer::paint(GeometryRenderer& renderer) const {
 			renderer.draw(std::get<Ray<Inexact>>(object));
 		} else if (std::holds_alternative<Polyline<Inexact>>(object)) {
 			renderer.draw(std::get<Polyline<Inexact>>(object));
+		} else if (std::holds_alternative<RenderPath>(object)) {
+			renderer.draw(std::get<RenderPath>(object));
 		} else if (std::holds_alternative<Label>(object)) {
 			renderer.drawText(std::get<Label>(object).first, std::get<Label>(object).second);
 		} else if (std::holds_alternative<Style>(object)) {
@@ -90,6 +92,10 @@ void PaintingRenderer::draw(const Ray<Inexact>& r) {
 }
 
 void PaintingRenderer::draw(const Polyline<Inexact>& p) {
+	m_objects.push_back(p);
+}
+
+void PaintingRenderer::draw(const RenderPath& p) {
 	m_objects.push_back(p);
 }
 

--- a/cartocrow/renderer/painting_renderer.cpp
+++ b/cartocrow/renderer/painting_renderer.cpp
@@ -29,8 +29,6 @@ void PaintingRenderer::paint(GeometryRenderer& renderer) const {
 	for (auto& object : m_objects) {
 		if (std::holds_alternative<Point<Inexact>>(object)) {
 			renderer.draw(std::get<Point<Inexact>>(object));
-		} else if (std::holds_alternative<Segment<Inexact>>(object)) {
-			renderer.draw(std::get<Segment<Inexact>>(object));
 		} else if (std::holds_alternative<Polygon<Inexact>>(object)) {
 			renderer.draw(std::get<Polygon<Inexact>>(object));
 		} else if (std::holds_alternative<PolygonWithHoles<Inexact>>(object)) {
@@ -61,10 +59,6 @@ void PaintingRenderer::paint(GeometryRenderer& renderer) const {
 
 void PaintingRenderer::draw(const Point<Inexact>& p) {
 	m_objects.push_back(p);
-}
-
-void PaintingRenderer::draw(const Segment<Inexact>& s) {
-	m_objects.push_back(s);
 }
 
 void PaintingRenderer::draw(const Polygon<Inexact>& p) {

--- a/cartocrow/renderer/painting_renderer.h
+++ b/cartocrow/renderer/painting_renderer.h
@@ -42,7 +42,6 @@ class PaintingRenderer : public GeometryPainting, public GeometryRenderer {
 	void draw(const BezierSpline& s) override;
 	void draw(const Line<Inexact>& l) override;
 	void draw(const Ray<Inexact>& r) override;
-	void draw(const Polyline<Inexact>& p) override;
 	void draw(const RenderPath& p) override;
 	void drawText(const Point<Inexact>& p, const std::string& text) override;
 
@@ -77,7 +76,7 @@ class PaintingRenderer : public GeometryPainting, public GeometryRenderer {
 	using Label = std::pair<Point<Inexact>, std::string>;
 	using DrawableObject =
 	    std::variant<Point<Inexact>, PolygonWithHoles<Inexact>, Circle<Inexact>, BezierSpline,
-	                 Line<Inexact>, Ray<Inexact>, Polyline<Inexact>, RenderPath, Label, Style>;
+	                 Line<Inexact>, Ray<Inexact>, RenderPath, Label, Style>;
 	std::vector<DrawableObject> m_objects;
 	Style m_style;
 };

--- a/cartocrow/renderer/painting_renderer.h
+++ b/cartocrow/renderer/painting_renderer.h
@@ -37,7 +37,6 @@ class PaintingRenderer : public GeometryPainting, public GeometryRenderer {
 	void paint(GeometryRenderer& renderer) const override;
 
 	void draw(const Point<Inexact>& p) override;
-	void draw(const Polygon<Inexact>& p) override;
 	void draw(const PolygonWithHoles<Inexact>& p) override;
 	void draw(const Circle<Inexact>& c) override;
 	void draw(const BezierSpline& s) override;
@@ -76,9 +75,9 @@ class PaintingRenderer : public GeometryPainting, public GeometryRenderer {
 		double m_fillOpacity = 255;
 	};
 	using Label = std::pair<Point<Inexact>, std::string>;
-	using DrawableObject = std::variant<Point<Inexact>, Polygon<Inexact>, PolygonWithHoles<Inexact>,
-	                                    Circle<Inexact>, BezierSpline, Line<Inexact>, Ray<Inexact>,
-	                                    Polyline<Inexact>, RenderPath, Label, Style>;
+	using DrawableObject =
+	    std::variant<Point<Inexact>, PolygonWithHoles<Inexact>, Circle<Inexact>, BezierSpline,
+	                 Line<Inexact>, Ray<Inexact>, Polyline<Inexact>, RenderPath, Label, Style>;
 	std::vector<DrawableObject> m_objects;
 	Style m_style;
 };

--- a/cartocrow/renderer/painting_renderer.h
+++ b/cartocrow/renderer/painting_renderer.h
@@ -37,7 +37,6 @@ class PaintingRenderer : public GeometryPainting, public GeometryRenderer {
 	void paint(GeometryRenderer& renderer) const override;
 
 	void draw(const Point<Inexact>& p) override;
-	void draw(const Segment<Inexact>& s) override;
 	void draw(const Polygon<Inexact>& p) override;
 	void draw(const PolygonWithHoles<Inexact>& p) override;
 	void draw(const Circle<Inexact>& c) override;
@@ -77,10 +76,9 @@ class PaintingRenderer : public GeometryPainting, public GeometryRenderer {
 		double m_fillOpacity = 255;
 	};
 	using Label = std::pair<Point<Inexact>, std::string>;
-	using DrawableObject =
-	    std::variant<Point<Inexact>, Segment<Inexact>, Polygon<Inexact>, PolygonWithHoles<Inexact>,
-	                 Circle<Inexact>, BezierSpline, Line<Inexact>, Ray<Inexact>, Polyline<Inexact>,
-	                 RenderPath, Label, Style>;
+	using DrawableObject = std::variant<Point<Inexact>, Polygon<Inexact>, PolygonWithHoles<Inexact>,
+	                                    Circle<Inexact>, BezierSpline, Line<Inexact>, Ray<Inexact>,
+	                                    Polyline<Inexact>, RenderPath, Label, Style>;
 	std::vector<DrawableObject> m_objects;
 	Style m_style;
 };

--- a/cartocrow/renderer/painting_renderer.h
+++ b/cartocrow/renderer/painting_renderer.h
@@ -17,8 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CARTOCROW_RENDERER_STORED_PAINTING_H
-#define CARTOCROW_RENDERER_STORED_PAINTING_H
+#ifndef CARTOCROW_RENDERER_PAINTING_RENDERER_H
+#define CARTOCROW_RENDERER_PAINTING_RENDERER_H
 
 #include "geometry_painting.h"
 #include "geometry_renderer.h"
@@ -45,6 +45,7 @@ class PaintingRenderer : public GeometryPainting, public GeometryRenderer {
 	void draw(const Line<Inexact>& l) override;
 	void draw(const Ray<Inexact>& r) override;
 	void draw(const Polyline<Inexact>& p) override;
+	void draw(const RenderPath& p) override;
 	void drawText(const Point<Inexact>& p, const std::string& text) override;
 
 	void pushStyle() override;
@@ -76,13 +77,14 @@ class PaintingRenderer : public GeometryPainting, public GeometryRenderer {
 		double m_fillOpacity = 255;
 	};
 	using Label = std::pair<Point<Inexact>, std::string>;
-	using DrawableObject = std::variant<Point<Inexact>, Segment<Inexact>, Polygon<Inexact>,
-	                                    PolygonWithHoles<Inexact>, Circle<Inexact>, BezierSpline,
-	                                    Line<Inexact>, Ray<Inexact>, Polyline<Inexact>, Label, Style>;
+	using DrawableObject =
+	    std::variant<Point<Inexact>, Segment<Inexact>, Polygon<Inexact>, PolygonWithHoles<Inexact>,
+	                 Circle<Inexact>, BezierSpline, Line<Inexact>, Ray<Inexact>, Polyline<Inexact>,
+	                 RenderPath, Label, Style>;
 	std::vector<DrawableObject> m_objects;
 	Style m_style;
 };
 
 } // namespace cartocrow::renderer
 
-#endif //CARTOCROW_RENDERER_STORED_PAINTING_H
+#endif //CARTOCROW_RENDERER_PAINTING_RENDERER_H

--- a/cartocrow/renderer/render_path.cpp
+++ b/cartocrow/renderer/render_path.cpp
@@ -1,0 +1,40 @@
+/*
+The CartoCrow library implements algorithmic geo-visualization methods,
+developed at TU Eindhoven.
+Copyright (C) 2021  Netherlands eScience Center and TU Eindhoven
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "render_path.h"
+
+namespace cartocrow::renderer {
+
+const std::vector<RenderPath::Command>& RenderPath::commands() const {
+	return m_commands;
+}
+
+void RenderPath::moveTo(Point<Inexact> to) {
+	m_commands.push_back(MoveTo{to});
+}
+
+void RenderPath::lineTo(Point<Inexact> to) {
+	m_commands.push_back(LineTo{to});
+}
+
+void RenderPath::close() {
+	m_commands.push_back(Close{});
+}
+
+} // namespace cartocrow::renderer

--- a/cartocrow/renderer/render_path.h
+++ b/cartocrow/renderer/render_path.h
@@ -1,0 +1,53 @@
+/*
+The CartoCrow library implements algorithmic geo-visualization methods,
+developed at TU Eindhoven.
+Copyright (C) 2021  Netherlands eScience Center and TU Eindhoven
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef CARTOCROW_RENDERER_RENDER_PATH_H
+#define CARTOCROW_RENDERER_RENDER_PATH_H
+
+#include <variant>
+
+#include "../core/core.h"
+
+namespace cartocrow::renderer {
+
+/// A path that can be drawn or filled.
+class RenderPath {
+  public:
+	struct MoveTo {
+		Point<Inexact> m_to;
+	};
+	struct LineTo {
+		Point<Inexact> m_to;
+	};
+	struct Close {};
+	using Command = std::variant<MoveTo, LineTo, Close>;
+
+	const std::vector<Command>& commands() const;
+
+	void moveTo(Point<Inexact> to);
+	void lineTo(Point<Inexact> to);
+	void close();
+
+  private:
+	std::vector<Command> m_commands;
+};
+
+}
+
+#endif //CARTOCROW_RENDERER_RENDER_PATH_H

--- a/demos/renderer/CMakeLists.txt
+++ b/demos/renderer/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(renderer_demo)
+add_subdirectory(render_path_demo)
 add_subdirectory(editables_demo)

--- a/demos/renderer/editables_demo/editables_demo.cpp
+++ b/demos/renderer/editables_demo/editables_demo.cpp
@@ -33,7 +33,9 @@ void DemoPainting::paint(GeometryRenderer& renderer) const {
 	renderer.setMode(GeometryRenderer::DrawMode::fill | GeometryRenderer::DrawMode::stroke);
 
 	// draw circle through the three points
-	renderer.draw(Circle<Inexact>(*m_p1, *m_p2, *m_p3));
+	if (!CGAL::collinear(*m_p1, *m_p2, *m_p3)) {
+		renderer.draw(Circle<Inexact>(*m_p1, *m_p2, *m_p3));
+	}
 	renderer.draw(*m_p1);
 	renderer.draw(*m_p2);
 	renderer.draw(*m_p3);

--- a/demos/renderer/render_path_demo/CMakeLists.txt
+++ b/demos/renderer/render_path_demo/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(SOURCES
+    render_path_demo.cpp
+)
+
+add_executable(render_path_demo ${SOURCES})
+
+target_link_libraries(
+    render_path_demo
+    PRIVATE
+    ${COMMON_CLA_TARGET}
+    core
+    renderer
+    Qt5::Widgets
+)
+
+install(TARGETS render_path_demo DESTINATION ${INSTALL_BINARY_DIR})

--- a/demos/renderer/render_path_demo/render_path_demo.cpp
+++ b/demos/renderer/render_path_demo/render_path_demo.cpp
@@ -1,0 +1,66 @@
+/*
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "render_path_demo.h"
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QDockWidget>
+#include <QGridLayout>
+#include <QMainWindow>
+#include <QPushButton>
+#include <QWidget>
+
+#include <cartocrow/renderer/render_path.h>
+
+using namespace cartocrow;
+using namespace cartocrow::renderer;
+
+void DemoPainting::paint(GeometryRenderer& renderer) const {
+	// set style
+	renderer.setStroke(Color{0, 0, 0}, 2.5);
+	renderer.setFill(Color{120, 170, 240});
+	renderer.setMode(GeometryRenderer::DrawMode::fill | GeometryRenderer::DrawMode::stroke);
+
+	// construct a RenderPath
+	RenderPath path;
+	path.moveTo(Point<Inexact>(0, 0));
+	path.lineTo(Point<Inexact>(50, 50));
+	path.lineTo(Point<Inexact>(70, -40));
+	path.close();
+	path.moveTo(Point<Inexact>(100, 0));
+	path.lineTo(Point<Inexact>(120, -50));
+	path.lineTo(Point<Inexact>(150, 30));
+
+	// draw various shapes
+	renderer.draw(path);
+}
+
+RenderPathDemo::RenderPathDemo() {
+	setWindowTitle("CartoCrow – Render path demo");
+
+	m_renderer = new GeometryWidget();
+	setCentralWidget(m_renderer);
+
+	std::shared_ptr<DemoPainting> painting = std::make_shared<DemoPainting>();
+	m_renderer->addPainting(painting, "Demo painting");
+}
+
+int main(int argc, char* argv[]) {
+	QApplication app(argc, argv);
+	RenderPathDemo demo;
+	demo.show();
+	app.exec();
+}

--- a/demos/renderer/render_path_demo/render_path_demo.h
+++ b/demos/renderer/render_path_demo/render_path_demo.h
@@ -1,0 +1,40 @@
+/*
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <QMainWindow>
+
+#include <cartocrow/core/core.h>
+#include <cartocrow/renderer/geometry_painting.h>
+#include <cartocrow/renderer/geometry_widget.h>
+
+using namespace cartocrow;
+using namespace cartocrow::renderer;
+
+/// The painting that is being drawn in the renderer demo.
+class DemoPainting : public GeometryPainting {
+	void paint(GeometryRenderer &renderer) const override;
+};
+
+/// A simple demo application that displays a \ref GeometryWidget with a few
+/// shapes in it, and allows changing its settings.
+class RenderPathDemo : public QMainWindow {
+	Q_OBJECT;
+
+  public:
+	RenderPathDemo();
+
+  private:
+	GeometryWidget* m_renderer;
+};


### PR DESCRIPTION
Adds a new class `RenderPath` which can be rendered. So far `RenderPath` just supports straight segments. This will be extended in future PRs.