### PR TITLE
Add a constructor to Color

### DIFF
--- a/cartocrow/core/core.cpp
+++ b/cartocrow/core/core.cpp
@@ -24,6 +24,7 @@ Created by tvl (t.vanlankveld@esciencecenter.nl) on 05-12-2019
 
 namespace cartocrow {
 
+Color::Color() : r(0), g(0), b(0) {}
 Color::Color(int r, int g, int b) : r(r), g(g), b(b) {}
 
 Number<Inexact> wrapAngle(Number<Inexact> alpha, Number<Inexact> beta) {

--- a/cartocrow/core/core.cpp
+++ b/cartocrow/core/core.cpp
@@ -24,6 +24,8 @@ Created by tvl (t.vanlankveld@esciencecenter.nl) on 05-12-2019
 
 namespace cartocrow {
 
+Color::Color(int r, int g, int b) : r(r), g(g), b(b) {}
+
 Number<Inexact> wrapAngle(Number<Inexact> alpha, Number<Inexact> beta) {
 	return wrap<Inexact>(alpha, beta, beta + M_2xPI);
 }

--- a/cartocrow/core/core.h
+++ b/cartocrow/core/core.h
@@ -170,6 +170,8 @@ struct Color {
 	int g;
 	/// Blue component (integer 0-255).
 	int b;
+	/// Constructs the color black.
+	Color();
 	/// Constructs a color.
 	Color(int r, int g, int b);
 };

--- a/cartocrow/core/core.h
+++ b/cartocrow/core/core.h
@@ -170,6 +170,8 @@ struct Color {
 	int g;
 	/// Blue component (integer 0-255).
 	int b;
+	/// Constructs a color.
+	Color(int r, int g, int b);
 };
 
 /// Wraps the given number \f$n\f$ to the interval \f$[a, b)\f$.


### PR DESCRIPTION
As noted by @Yvee1, if you don't do this, until C++20 you can't emplace Colors into an `std::vector<Color>` and you can't `make_shared` them.