### PR TITLE
Use href instead of xlink:href in the SVG renderer

### DIFF
--- a/cartocrow/renderer/svg_renderer.cpp
+++ b/cartocrow/renderer/svg_renderer.cpp
@@ -60,7 +60,7 @@ void SvgRenderer::save(const std::filesystem::path& file) {
 }
 
 void SvgRenderer::draw(const Point<Inexact>& p) {
-	m_out << "<use xlink:href=\"#vertex\" " << getVertexStyle() << " x=\"" << p.x() << "\" y=\""
+	m_out << "<use href=\"#vertex\" " << getVertexStyle() << " x=\"" << p.x() << "\" y=\""
 	      << -p.y() << "\"/>\n";
 }
 


### PR DESCRIPTION
xlink:href is SVG 1.1 and does no longer work in modern web browsers. The SVG 2 equivalent is href without the namespace prefix.  Inkscape 1.2 (which is sadly still the default in current Ubuntu versions) doesn't support href. Inkscape >= 1.3 does, however, so affected users can simply install a newer Inkscape version to view and edit generated SVG files.

Fixes #51.